### PR TITLE
Upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v5
- upgrade actions/setup-node from v4 to v5

This keeps the workflow on the Node 24-compatible action releases while leaving the Gatsby build on Node 22.

## Verification
- Prettier check passes
- git diff --check passes