### PR TITLE
Move remaining Pages actions to Node 24

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -36,12 +36,12 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           static_site_generator: gatsby
 
       - name: Restore Gatsby cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             public
@@ -59,7 +59,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- upgrade pnpm/action-setup from v4 to v6
- upgrade configure-pages from v5 to v6
- upgrade cache from v4 to v5
- upgrade upload-pages-artifact from v3 to v4
- upgrade deploy-pages from v4 to v5

These updates remove the remaining Node 20 action runtimes while keeping the Gatsby build on Node 22.

## Verification
- Prettier check passes
- git diff --check passes